### PR TITLE
Minikube support: Specify imagePullPolicy: IfNotPresent

### DIFF
--- a/scripts/kubernetes/nginx.yaml
+++ b/scripts/kubernetes/nginx.yaml
@@ -38,6 +38,7 @@ spec:
                   - "-s"
                   - quit
           name: nginx
+          imagePullPolicy: IfNotPresent
           ports:
             -
               containerPort: 80

--- a/scripts/kubernetes/php-cli.yaml
+++ b/scripts/kubernetes/php-cli.yaml
@@ -101,6 +101,7 @@ spec:
                   name: service-credentials
           image: "registry.ng.bluemix.net/jjdojo/code-php-cli:latest"
           name: php-cli
+          imagePullPolicy: IfNotPresent
           volumeMounts:
             -
               mountPath: /var/www/html/sites/default/files

--- a/scripts/kubernetes/php-fpm.yaml
+++ b/scripts/kubernetes/php-fpm.yaml
@@ -115,6 +115,7 @@ spec:
                   name: service-credentials
           image: "registry.ng.bluemix.net/jjdojo/code-php-fpm:latest"
           name: php-fpm
+          imagePullPolicy: IfNotPresent
           ports:
             -
               containerPort: 9000


### PR DESCRIPTION
- Kubernetes is always trying to pull the image from the registry, even if it exists.
- Setting pull policy to "IfNotPresent" forces Kubernetes to recycle existing images, if they exist.